### PR TITLE
Example of beakerlib test working

### DIFF
--- a/tests/roles/beakerlib/tasks/main.yml
+++ b/tests/roles/beakerlib/tasks/main.yml
@@ -1,12 +1,44 @@
 ---
+- name: Add restraint repo for restraint-rhts on Fedora hosts
+  blockinfile:
+    create: yes
+    dest: /etc/yum.repos.d/restraint.repo
+    block: |
+     [Restraint]
+     name=Copr repo for restraint owned by bpeck
+     baseurl=http://copr-be.cloud.fedoraproject.org/results/bpeck/restraint/fedora-{{ ansible_distribution_major_version }}-{{ ansible_userspace_architecture}}/
+     skip_if_unavailable=True
+     gpgcheck=0
+     enabled=1
+  when: ansible_distribution == 'Fedora'
+  tags:
+  - prepare
+
+- name: Add restraint repo for restraint-rhts on RHEL/CentOS x86_64 Hosts
+  blockinfile:
+    create: yes
+    dest: /etc/yum.repos.d/restraint.repo
+    block: |
+     [Restraint]
+     name=Copr repo for restraint owned by bpeck
+     baseurl=http://copr-be.cloud.fedoraproject.org/results/bpeck/restraint/epel-7-x86_64/
+     skip_if_unavailable=True
+     gpgcheck=0
+     enabled=1
+  when: (ansible_distribution == 'RedHat' or ansible_distribution == 'CentOS') and ansible_userspace_architecture == 'x86_64'
+  tags:
+  - prepare
+
+
 - name: Install the beakerlib requirements
   package: name={{item}} state=latest
   with_items:
   - beakerlib
+  - restraint-rhts
   tags:
   - prepare
 
-- name: Put beakerlib binaries on the target
+- name: Put beakerlib and rhts binaries on the target
   copy:
     src: "{{item}}"
     dest: /usr/local/bin/
@@ -14,6 +46,8 @@
   with_fileglob:
     - "/usr/bin/beakerlib-*"
     - "/usr/share/beakerlib/*"
+    - "/usr/bin/rhts-*"
+    - "/usr/share/rhts/*"
     - "rpm.py"
 
 - name: Copy tests to target
@@ -24,8 +58,16 @@
 - name: Fix up beakerlib
   shell: "find /usr/local/bin -type f | xargs sed -i 's|/usr/share/beakerlib|/usr/local/bin|g'"
 
-- name: Make artifacts directory
-  file: path={{ artifacts }} state=directory owner=root mode=755 recurse=yes
+- name: Make artifacts and mnt/testarea directory
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: root
+    mode: 755
+    recurse: yes
+  with_items:
+  - "{{ artifacts }}"
+  - /mnt/testarea
 
 - block:
   - name: Execute beakerlib test
@@ -37,8 +79,8 @@
     shell: "if grep ' FAIL ' /tmp/test.log; then exit 1; else exit 0; fi"
 
 - always:
-  - name: Pull out the logs
-    fetch:
-      dest: "{{artifacts}}/"
-      src: "{{artifacts}}/"
-      flat: yes
+   - name: Pull out the logs
+     synchronize:
+       dest: "{{artifacts}}/"
+       src: "{{artifacts}}/"
+       mode: pull

--- a/tests/roles/beakerlib/tasks/main.yml
+++ b/tests/roles/beakerlib/tasks/main.yml
@@ -1,34 +1,19 @@
 ---
 - name: Add restraint repo for restraint-rhts on Fedora hosts
-  blockinfile:
-    create: yes
+  get_url:
+    url: https://copr.fedorainfracloud.org/coprs/bpeck/restraint/repo/fedora-{{ansible_distribution_major_version}}/bpeck-restraint-fedora-{{ansible_distribution_major_version}}.repo
     dest: /etc/yum.repos.d/restraint.repo
-    block: |
-     [Restraint]
-     name=Copr repo for restraint owned by bpeck
-     baseurl=http://copr-be.cloud.fedoraproject.org/results/bpeck/restraint/fedora-{{ ansible_distribution_major_version }}-{{ ansible_userspace_architecture}}/
-     skip_if_unavailable=True
-     gpgcheck=0
-     enabled=1
   when: ansible_distribution == 'Fedora'
   tags:
   - prepare
 
 - name: Add restraint repo for restraint-rhts on RHEL/CentOS x86_64 Hosts
-  blockinfile:
-    create: yes
+  get_url:
+    url: https://copr.fedorainfracloud.org/coprs/bpeck/restraint/repo/epel-7/bpeck-restraint-epel-7.repo
     dest: /etc/yum.repos.d/restraint.repo
-    block: |
-     [Restraint]
-     name=Copr repo for restraint owned by bpeck
-     baseurl=http://copr-be.cloud.fedoraproject.org/results/bpeck/restraint/epel-7-x86_64/
-     skip_if_unavailable=True
-     gpgcheck=0
-     enabled=1
-  when: (ansible_distribution == 'RedHat' or ansible_distribution == 'CentOS') and ansible_userspace_architecture == 'x86_64'
+  when: ansible_distribution == 'RedHat' or ansible_distribution == 'CentOS'
   tags:
   - prepare
-
 
 - name: Install the beakerlib requirements
   package: name={{item}} state=latest

--- a/tests/test-sed-does-not-handle-inline-edits-of-symlinks-with
+++ b/tests/test-sed-does-not-handle-inline-edits-of-symlinks-with
@@ -1,0 +1,58 @@
+#!/bin/bash
+# vim: dict=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   runtest.sh of /CoreOS/sed/Regression/bz490473-sed-does-not-handle-inline-edits-of-symlinks-with
+#   Description: Test for bz490473 (sed does not handle inline edits of symlinks with)
+#   Author: Marek Polacek <mpolacek@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2011 Red Hat, Inc. All rights reserved.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Include rhts environment
+#. /usr/bin/rhts-environment.sh
+#. /usr/lib/beakerlib/beakerlib.sh
+. /usr/local/bin/rhts-environment.sh
+. /usr/local/bin/beakerlib.sh
+
+PACKAGE="sed"
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlAssertRpm $PACKAGE
+        rlRun "TmpDir=\`mktemp -d\`" 0 "Creating tmp directory"
+        rlRun "pushd $TmpDir"
+	# Prepare the test file
+	rlRun "echo 'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz' > 1" 0
+	# Create a symlink
+	rlRun "ln -s 1 2" 0
+    rlPhaseEnd
+
+    rlPhaseStartTest
+        # Try to replace characters
+        rlRun "sed -i -e 's/z/a/g' 2 " 0 "Replace all z's with a's"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "popd"
+        rlRun "rm -r $TmpDir" 0 "Removing tmp directory"
+    rlPhaseEnd
+rlJournalPrintText
+rlJournalEnd

--- a/tests/test_local.yml
+++ b/tests/test_local.yml
@@ -2,4 +2,4 @@
 # This first play always runs on the local staging system
 - hosts: localhost
   roles:
-  - { role: beakerlib, tests: [ test-uppercase-operand ] }
+  - { role: beakerlib, tests: [ test-uppercase-operand, test-sed-does-not-handle-inline-edits-of-symlinks-with ] }


### PR DESCRIPTION
This PR shows one way to get a true beakerlib test working in this workflow.  I called it as follows (there may be an easier way to do the same thing):
Change hosts: localhost to hosts: all in tests/test_local.yml
ansible-playbook -i "localhost," -c local tests/test_local.yml --tags prepare
ansible-playbook -i ./inventory tests/tests_local.yml --skip-tags prepare

Caveats:
- As you can see in tests/test-sed-does-not-handle-inline-edits-of-symlinks-with, I had to change the path for the includes as the binaries are copied to /usr/local/bin instead.  That is the only change I had to make to the test, however.
- All the output goes to artifacts/test.log, which does not too clearly differentiate between the different tests.

I changed from fetch to synchronize in beakerlib/tasks/main.yml so that if the artifacts directory eventually has multiple files, we get them all, as fetch only supports fetching one file at a time.